### PR TITLE
Change label's text color when highlighted.

### DIFF
--- a/OHAttributedLabel.m
+++ b/OHAttributedLabel.m
@@ -210,6 +210,9 @@ CTLineBreakMode CTLineBreakModeFromUILineBreakMode(UILineBreakMode lineBreakMode
 		
 		NSMutableAttributedString* attrStrWithLinks = [self attributedTextWithLinks];
 		
+		if (self.highlighted)
+			[attrStrWithLinks setTextColor:self.highlightedTextColor];
+
 		CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString((CFAttributedStringRef)attrStrWithLinks);
 		CGRect rect = self.bounds;
 		if (self.centerVertically) {

--- a/OHAttributedLabel.m
+++ b/OHAttributedLabel.m
@@ -210,7 +210,7 @@ CTLineBreakMode CTLineBreakModeFromUILineBreakMode(UILineBreakMode lineBreakMode
 		
 		NSMutableAttributedString* attrStrWithLinks = [self attributedTextWithLinks];
 		
-		if (self.highlighted)
+		if (self.highlighted && self.highlightedTextColor != nil)
 			[attrStrWithLinks setTextColor:self.highlightedTextColor];
 
 		CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString((CFAttributedStringRef)attrStrWithLinks);


### PR DESCRIPTION
I used the OHAttributedLabel as a subview of a UITableViewCell. When the table cell is tapped, regular labels switch their text color to the highlighted color. OHAttributedLabel did not do this, so I added it in. Seems to work just fine. :-)
