### PR TITLE
Importing UIKit headers

### DIFF
--- a/NSAttributedString+Attributes.h
+++ b/NSAttributedString+Attributes.h
@@ -31,6 +31,7 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreText/CoreText.h>
+#import <UIKit/UIKit.h>
 
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hi,

I added an import of UIKit/UIKit.h to the NSAttributed string category.
In our projects we decided to remove the UIKit import from the pch to make it more descriptive which classes are depending on UI code. This helps us to keep our code portable between Mac & iOS and even helps us to find classes that need attention when it comes to iPhone and iPad.

Thanks for OHAttributedLabel. We're just doing our first integration and hope that it becomes a regular in our code base :D

Best,
Ullrich
