### PR TITLE
Added linkColor (UIColor) and underlineLinks (BOOL) properties

### DIFF
--- a/OHAttributedLabel.h
+++ b/OHAttributedLabel.h
@@ -44,6 +44,8 @@
 @interface OHAttributedLabel : UILabel {
 	NSMutableAttributedString* _attributedText; //!< Internally mutable, but externally immutable copy access only
 	CTFrameRef textFrame;
+	UIColor* linkColor;
+	BOOL underlineLinks;
 	BOOL centerVertically;
 	BOOL automaticallyDetectLinks;
 	BOOL onlyCatchTouchesOnLinks;
@@ -52,6 +54,8 @@
 	BOOL extendBottomToFit;
 }
 @property(nonatomic, copy) NSAttributedString* attributedText; //!< Use this instead of the "text" property inherited from UILabel to set and get text
+@property(nonatomic, retain) UIColor* linkColor; //!< Defaults to [UIColor blueColor]
+@property(nonatomic, assign) BOOL underlineLinks; //!< Defaults to YES
 @property(nonatomic, assign) BOOL centerVertically;
 @property(nonatomic, assign) BOOL automaticallyDetectLinks; //!< Defaults to YES
 @property(nonatomic, assign) BOOL onlyCatchTouchesOnLinks; //!< If YES, pointInside will only return YES if the touch is on a link. If NO, pointInside will always return YES (Defaults to NO)

--- a/OHAttributedLabel.m
+++ b/OHAttributedLabel.m
@@ -65,7 +65,7 @@ CTLineBreakMode CTLineBreakModeFromUILineBreakMode(UILineBreakMode lineBreakMode
 
 
 @implementation OHAttributedLabel
-@synthesize centerVertically, automaticallyDetectLinks, onlyCatchTouchesOnLinks, extendBottomToFit;
+@synthesize linkColor, underlineLinks, centerVertically, automaticallyDetectLinks, onlyCatchTouchesOnLinks, extendBottomToFit;
 @synthesize delegate;
 
 
@@ -77,6 +77,8 @@ CTLineBreakMode CTLineBreakModeFromUILineBreakMode(UILineBreakMode lineBreakMode
 
 - (void)commonInit {
 	customLinks = [[NSMutableArray alloc] init];
+	linkColor = [[UIColor blueColor] retain];
+	underlineLinks = YES;
 	automaticallyDetectLinks = YES;
 	onlyCatchTouchesOnLinks = NO;
 	self.userInteractionEnabled = YES;
@@ -105,6 +107,7 @@ CTLineBreakMode CTLineBreakModeFromUILineBreakMode(UILineBreakMode lineBreakMode
 -(void)dealloc {
 	[_attributedText release];
 	[customLinks release];
+	[linkColor release];
 	if (textFrame) CFRelease(textFrame);
 	[super dealloc];
 }
@@ -134,19 +137,23 @@ CTLineBreakMode CTLineBreakModeFromUILineBreakMode(UILineBreakMode lineBreakMode
 		[linkDetector enumerateMatchesInString:[str string] options:0 range:NSMakeRange(0,[[str string] length])
 									usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop)
 		 {
-			 UIColor* linkColor = (delegate && [delegate respondsToSelector:@selector(colorForLink:)])
-			 ? [delegate colorForLink:result] : [UIColor blueColor];
-			 [str setTextColor:linkColor range:[result range]];
-			 [str setTextIsUnderlined:YES range:[result range]];
+			 UIColor* thisLinkColor = (delegate && [delegate respondsToSelector:@selector(colorForLink:)])
+			 ? [delegate colorForLink:result] : self.linkColor;
+			 if (thisLinkColor)
+				 [str setTextColor:thisLinkColor range:[result range]];
+			 if (self.underlineLinks)
+				 [str setTextIsUnderlined:YES range:[result range]];
 		 }];
 	}
 	[customLinks enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop)
 	 {
 		 NSTextCheckingResult* result = (NSTextCheckingResult*)obj;
-		 UIColor* linkColor = (delegate && [delegate respondsToSelector:@selector(colorForLink:)])
-		 ? [delegate colorForLink:result] : [UIColor blueColor];
-		 [str setTextColor:linkColor range:[result range]];
-		 [str setTextIsUnderlined:YES range:[result range]];
+		 UIColor* thisLinkColor = (delegate && [delegate respondsToSelector:@selector(colorForLink:)])
+		 ? [delegate colorForLink:result] : self.linkColor;
+		 if (thisLinkColor)
+			 [str setTextColor:thisLinkColor range:[result range]];
+		 if (self.underlineLinks)
+			 [str setTextIsUnderlined:YES range:[result range]];
 	 }];
 	return [str autorelease];
 }


### PR DESCRIPTION
Two more properties to allow users to customize how the links are displayed. linkColor can be nil to disable automatic link coloring, which together with underlineLinks=NO completely disables automatic link formatting.

Thanks for your recent work, the new touch detection works much better now!

Frederik
