### PR TITLE
Fixed a crash caused by dealloc not resetting textFrame to NULL after rel

### DIFF
--- a/OHAttributedLabel.m
+++ b/OHAttributedLabel.m
@@ -171,7 +171,10 @@ BOOL CTRunContainsCharactersFromStringRange(CTRunRef run, NSRange range) {
 	[customLinks release];
 	[linkColor release];
 	[highlightedLinkColor release];
-	if (textFrame) CFRelease(textFrame);
+	if (textFrame) {
+            CFRelease(textFrame);
+            textFrame = NULL;
+        }
 	[activeLink release];
 	[super dealloc];
 }


### PR DESCRIPTION
Fixed a crash caused by dealloc not resetting textFrame to NULL after releasing the reference (a subsequent call to resetTextFrame would pass the if conditional and crash on trying to release the memory.)
