### PR TITLE
Very minor change, makes OHAttributedLabel a better "class citizen"

### DIFF
--- a/OHAttributedLabel.m
+++ b/OHAttributedLabel.m
@@ -423,7 +423,7 @@ BOOL CTRunContainsCharactersFromStringRange(CTRunRef run, NSRange range) {
 		}
 		if (textFrame == NULL) {
 			CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString((CFAttributedStringRef)attrStrWithLinks);
-			drawingRect = self.bounds;
+			drawingRect = aRect;
 			if (self.centerVertically || self.extendBottomToFit) {
 				CGSize sz = CTFramesetterSuggestFrameSizeWithConstraints(framesetter,CFRangeMake(0,0),NULL,CGSizeMake(drawingRect.size.width,CGFLOAT_MAX),NULL);
 				if (self.extendBottomToFit) {


### PR DESCRIPTION
drawTextInRect: now respects the rect that is passed to it as the real drawingRect.
This enables a subclass that overrides drawInRect: to call drawTextInRect: with a reduced area, and OHAttributedLabel will behave as if that is its only area of concern.
