### PR TITLE
Fixes issue where brief touches on a link are ignored

### DIFF
--- a/OHAttributedLabel.h
+++ b/OHAttributedLabel.h
@@ -62,6 +62,7 @@ CTLineBreakMode CTLineBreakModeFromUILineBreakMode(UILineBreakMode lineBreakMode
 	CGRect drawingRect;
 	NSMutableArray* customLinks;
 	NSTextCheckingResult* activeLink;
+	CGPoint touchStartPoint;
 }
 
 /* Attributed String accessors */

--- a/OHAttributedLabel.m
+++ b/OHAttributedLabel.m
@@ -371,6 +371,7 @@ BOOL CTRunContainsCharactersFromStringRange(CTRunRef run, NSRange range) {
 	
 	[activeLink release];
 	activeLink = [[self linkAtPoint:pt] retain];
+	touchStartPoint = pt;
 	
 	// we're using activeLink to draw a highlight in -drawRect:
 	[self setNeedsDisplay];
@@ -382,8 +383,10 @@ BOOL CTRunContainsCharactersFromStringRange(CTRunRef run, NSRange range) {
 	
 	NSTextCheckingResult *linkAtTouchesEnded = [self linkAtPoint:pt];
 	
+	BOOL closeToStart = (abs(touchStartPoint.x - pt.x) < 10 && abs(touchStartPoint.y - pt.y) < 10);
+
 	// we can check on equality of the ranges themselfes since the data detectors create new results
-	if (activeLink && NSEqualRanges(activeLink.range,linkAtTouchesEnded.range)) {
+	if (activeLink && (NSEqualRanges(activeLink.range,linkAtTouchesEnded.range) || closeToStart)) {
 		BOOL openLink = (self.delegate && [self.delegate respondsToSelector:@selector(attributedLabel:shouldFollowLink:)])
 		? [self.delegate attributedLabel:self shouldFollowLink:activeLink] : YES;
 		if (openLink) [[UIApplication sharedApplication] openURL:activeLink.URL];


### PR DESCRIPTION
Added an additional case to accept the touches for a link, where the end-touch point is less than 10px (in x & y) from the start point. 

This fixes an issue where (for some reason) touches on a link are ignored if the touches are very brief. I believe if you tap a link, it should open the link, even for a brief touch.
