### PR TITLE
Accessibility label not being updated when attributed text is set

### DIFF
--- a/OHAttributedLabel.m
+++ b/OHAttributedLabel.m
@@ -560,6 +560,7 @@ BOOL CTRunContainsCharactersFromStringRange(CTRunRef run, NSRange range) {
 -(void)setAttributedText:(NSAttributedString*)attributedText {
 	[_attributedText release];
 	_attributedText = [attributedText mutableCopy];
+	[self setAccessibilityLabel:_attributedText.string];
 	[self removeAllCustomLinks];
 	[self setNeedsDisplay];
 }


### PR DESCRIPTION
The default UILabel code updates accessibilityLabel when its text is updated, but OHAttributedLabel does not.  This affects accessibility (natch) as well as automation.
