### PR TITLE
Fixed issue #76 - HighlightedTextColor for UITableViewCell selected row no longer working correctly

### DIFF
--- a/OHAttributedLabel.m
+++ b/OHAttributedLabel.m
@@ -433,6 +433,8 @@ BOOL CTRunContainsCharactersFromStringRange(CTRunRef run, NSRange range) {
 		NSMutableAttributedString* attrStrWithLinks = [self attributedTextWithLinks];
 		if (self.highlighted && self.highlightedTextColor != nil) {
 			[attrStrWithLinks setTextColor:self.highlightedTextColor];
+		} else {
+			[attrStrWithLinks setTextColor:self.textColor];
 		}
 		if (textFrame == NULL) {
 			CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString((CFAttributedStringRef)attrStrWithLinks);


### PR DESCRIPTION
Fixed issue #76 HighlightedTextColor for UITableViewCell selected row no longer working correctly
