### PR TITLE
Fixes for linkColor introduced by the highlightedText reset bug fix

### DIFF
--- a/OHAttributedLabel.m
+++ b/OHAttributedLabel.m
@@ -265,6 +265,10 @@ const int UITextAlignmentJustify = ((UITextAlignment)kCTJustifiedTextAlignment);
     {
 		return nil;
 	}
+
+    // Reset the main text color
+    [_attributedText setTextColor:self.textColor];
+    
     if (self.automaticallyAddLinksForType == 0 && customLinks.count == 0)
     {
 		return _attributedText;
@@ -484,8 +488,6 @@ const int UITextAlignmentJustify = ((UITextAlignment)kCTJustifiedTextAlignment);
 		if (self.highlighted && self.highlightedTextColor != nil)
         {
 			[attrStrWithLinks setTextColor:self.highlightedTextColor];
-		} else {
-			[attrStrWithLinks setTextColor:self.textColor];
 		}
 		if (textFrame == NULL)
         {


### PR DESCRIPTION
This fixes the issue introduced in [17e1f63768](https://github.com/AliSoftware/OHAttributedLabel/commit/17e1f63768539b8186cdc9d22e7cc6e4b306c59d) that was not honoring linkColor by overwriting it.

It moves the setting of the default text color to the _beginning_ of the attributedTextWithLinks call, so that linkColor can be nicely applied on top of that, and then the highlightedTextColor can overwrite all of it (if needed) as intended.
