### PR TITLE
Rename UIColorFromString() to avoid namespace collisions

### DIFF
--- a/OHAttributedLabel/TagParsers/OHASBasicHTMLParser.m
+++ b/OHAttributedLabel/TagParsers/OHASBasicHTMLParser.m
@@ -71,7 +71,7 @@
                 if ((colorRange.length>0) && (textRange.length>0))
                 {
                     NSString* colorName = [str attributedSubstringFromRange:colorRange].string;
-                    UIColor* color = UIColorFromString(colorName);
+                    UIColor* color = OHUIColorFromString(colorName);
                     NSMutableAttributedString* foundString = [[str attributedSubstringFromRange:textRange] mutableCopy];
                     [foundString setTextColor:color];
                     return MRC_AUTORELEASE(foundString);

--- a/OHAttributedLabel/TagParsers/OHASBasicMarkupParser.m
+++ b/OHAttributedLabel/TagParsers/OHASBasicMarkupParser.m
@@ -68,7 +68,7 @@
                 if ((colorRange.length>0) && (textRange.length>0))
                 {
                     NSString* colorName = [str attributedSubstringFromRange:colorRange].string;
-                    UIColor* color = UIColorFromString(colorName);
+                    UIColor* color = OHUIColorFromString(colorName);
                     NSMutableAttributedString* foundString = [[str attributedSubstringFromRange:textRange] mutableCopy];
                     [foundString setTextColor:color];
                     return MRC_AUTORELEASE(foundString);

--- a/OHAttributedLabel/TagParsers/OHASMarkupParserBase.h
+++ b/OHAttributedLabel/TagParsers/OHASMarkupParserBase.h
@@ -63,4 +63,4 @@ typedef NSAttributedString*(^TagProcessorBlockType)(NSAttributedString*, NSTextC
  * Support "#rgb", "#rgba", "#rrggbb" and "#rrggbbaa" hexadecimal representations (e.g. "#ffcc00")
  * Support also named colors exposed by UIColor class commodity "xxxColor" constructors, namely "red", "green", "blue", etc
  */
-UIColor* UIColorFromString(NSString* colorString);
+UIColor* OHUIColorFromString(NSString* colorString);

--- a/OHAttributedLabel/TagParsers/OHASMarkupParserBase.m
+++ b/OHAttributedLabel/TagParsers/OHASMarkupParserBase.m
@@ -75,7 +75,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - String to Color function
 
-UIColor* UIColorFromString(NSString* colorString)
+UIColor* OHUIColorFromString(NSString* colorString)
 {
     UIColor* color = nil;
     if ([colorString hasPrefix:@"#"])


### PR DESCRIPTION
Described in Issue 100.
