### PR TITLE
Update OHAttributedLabel/Source/NSAttributedString+Attributes.m

### DIFF
--- a/OHAttributedLabel/Source/NSAttributedString+Attributes.m
+++ b/OHAttributedLabel/Source/NSAttributedString+Attributes.m
@@ -228,10 +228,10 @@ NSString* kOHLinkAttributeName = @"NSLinkAttributeName"; // Use the same value a
 	do {
 		// Get font at startPoint
 		CTFontRef currentFont = (BRIDGE_CAST CTFontRef)[self attribute:(BRIDGE_CAST NSString*)kCTFontAttributeName atIndex:startPoint effectiveRange:&effectiveRange];
+        	BOOL shouldReleaseFont = NO;
         if (!currentFont)
         {
             currentFont = CTFontCreateUIFontForLanguage(kCTFontLabelFontType, 0.0, NULL);
-            (void)MRC_AUTORELEASE((BRIDGE_CAST id)currentFont);
         }
 		// The range for which this font is effective
 		NSRange fontRange = NSIntersectionRange(range, effectiveRange);
@@ -248,6 +248,7 @@ NSString* kOHLinkAttributeName = @"NSLinkAttributeName"; // Use the same value a
                   (BRIDGE_CAST NSString*)fontName);
             if (fontName) CFRelease(fontName);
 		}
+		if (currentFont && shouldReleaseFont) CFRelease(currentFont);
 		////[self removeAttribute:(NSString*)kCTFontWeightTrait range:fontRange]; // Work around for Apple leak
 		////[self addAttribute:(NSString*)kCTFontWeightTrait value:(id)[NSNumber numberWithInt:1.0f] range:fontRange];
 		


### PR DESCRIPTION
- Fixed memory leak CTFontRef, a CF object was not released in ARC since ARC does not release CF objects.
