### PR TITLE
Apply vertical alignment only if text is smaller than drawing area

### DIFF
--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -544,7 +544,7 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
                         drawingRect.origin.y -= delta;
                         drawingRect.size.height += delta;
                     }
-                    if (self.centerVertically)
+                    if (self.centerVertically && drawingRect.size.height > sz.height)
                     {
                         drawingRect.origin.y -= (drawingRect.size.height - sz.height)/2;
                     }


### PR DESCRIPTION
If text is too large to fit, don't attempt to center.  This avoids having part of a line cut-off at the top of your drawing region.
