### PR TITLE
Respect the attributedText property's 'copy' attribute.

### DIFF
--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -691,7 +691,7 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
 -(void)setAttributedText:(NSAttributedString*)newText
 {
 	MRC_RELEASE(_attributedText);
-	_attributedText = MRC_RETAIN(newText);
+	_attributedText = [newText copy];
 	[self setAccessibilityLabel:_attributedText.string];
 	[self removeAllCustomLinks];
     [self setNeedsRecomputeLinksInText];


### PR DESCRIPTION
attributedText is defined as a copy accessor, so we need to `-copy`
the NSAttributedString's value in `-setAttributeText:`.
