### PR TITLE
Updated README to remind users to add OHAttributedLabel it to their Target Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ There are two possible methods to include these classes in your project:
     * Include the `OHAttributedLabel.xcodeproj` project in your Xcode4 workspace
     * Build this `OHAttributedLabel.xcodeproj` project once for the "iOS Device" (not the simulator) _(1)_
     * Add `libOHAttributedLabel.a` **and `CoreText.framework`** to your **"Link Binary With Libraries"** Build Phase of your app project.
+    * Add OHAttributedLabel to your "Target Dependencies" Build Phase.
     * Select the `libOHAttributedLabel.a` that has just been added to your app project in your Project Navigator on the left, and change the "Location" dropdown in the File Inspector to **"Relative to Build Products"** _(1)_
     * Add the **`-ObjC` flag in the "Other Linker Flags"** Build Setting (if not present already)
 


### PR DESCRIPTION
Love OHAttributedLabel, thanks so much!

When we integrated it manually via the instructions we found that command line builds were failing on our continuous integration server. Turns out we just needed to add it as a Target Dependency so that Xcode knows to build it before your main target. This pull request is just a one line change to the README. I think it also makes it so you no longer need to explicitly go in and build OHAttributedLabel in step 2.
