### PR TITLE
Ability to activate a link on touchBegin as well as touchEnd.

### DIFF
--- a/OHAttributedLabel/Source/OHAttributedLabel.h
+++ b/OHAttributedLabel/Source/OHAttributedLabel.h
@@ -105,6 +105,8 @@ typedef NS_OPTIONS(int32_t, OHBoldStyleTrait) {
 
 //! If YES, pointInside will only return YES if the touch is on a link. If NO, pointInside will always return YES (Defaults to YES)
 @property(nonatomic, assign) BOOL onlyCatchTouchesOnLinks;
+//! If YES, any touched links are process on touchBegin, otherwise on touchEnd (Defaults to NO)
+@property(nonatomic, assign) BOOL catchTouchesOnLinksOnTouchBegan;
 //! The delegate that gets informed when a link is touched and gives the opportunity to catch it
 @property(nonatomic, assign) IBOutlet id<OHAttributedLabelDelegate> delegate;
 

--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -449,7 +449,10 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
 	
 	self.activeLink = [self linkAtPoint:pt];
 	_touchStartPoint = pt;
-	
+
+	if (_catchTouchesOnLinksOnTouchBegan) {
+		[self processLinkAt:pt];
+	}
 	// we're using activeLink to draw a highlight in -drawRect:
 	[self setNeedsDisplay];
 }
@@ -458,9 +461,15 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
 {
 	UITouch* touch = [touches anyObject];
 	CGPoint pt = [touch locationInView:self];
-	
+	if (!_catchTouchesOnLinksOnTouchBegan) {
+		[self processLinkAt:pt];
+	}
+	[self setNeedsDisplay];
+}
+
+- (void)processLinkAt:(CGPoint)pt {
 	NSTextCheckingResult *linkAtTouchesEnded = [self linkAtPoint:pt];
-	
+
 	BOOL closeToStart = (abs(_touchStartPoint.x - pt.x) < 10 && abs(_touchStartPoint.y - pt.y) < 10);
 
 	// we can check on equality of the ranges themselfes since the data detectors create new results
@@ -476,9 +485,8 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
             [[UIApplication sharedApplication] openURL:linkToOpen.extendedURL];
         }
 	}
-	
+
 	self.activeLink = nil;
-	[self setNeedsDisplay];
 }
 
 -(void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event


### PR DESCRIPTION
Hey there, would you consider integrating this into the source? It provides the ability to tweak the link activation based on a property, to allow links to activate when the user touches them instead of when they stop touching them?

Thanks,
Joe
