### PR TITLE
Use gesture recognizers instead of touches(Began|Ended|Cancelled)

### DIFF
--- a/OHAttributedLabel/OHAttributedLabel.xcodeproj/project.pbxproj
+++ b/OHAttributedLabel/OHAttributedLabel.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		09E15A26160F63DE003025B4 /* CoreTextUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E15A24160F63DE003025B4 /* CoreTextUtils.m */; };
 		09E15A2A160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E15A28160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.m */; };
 		09E15A2C160F64EB003025B4 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09E15A2B160F64EB003025B4 /* UIKit.framework */; };
+		C99D190217044B6300050CDC /* OHTouchesGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = C99D190117044B6200050CDC /* OHTouchesGestureRecognizer.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -70,6 +71,8 @@
 		09E15A27160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSTextCheckingResult+ExtendedURL.h"; sourceTree = "<group>"; };
 		09E15A28160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSTextCheckingResult+ExtendedURL.m"; sourceTree = "<group>"; };
 		09E15A2B160F64EB003025B4 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		C99D190017044B6200050CDC /* OHTouchesGestureRecognizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OHTouchesGestureRecognizer.h; sourceTree = "<group>"; };
+		C99D190117044B6200050CDC /* OHTouchesGestureRecognizer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OHTouchesGestureRecognizer.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -156,6 +159,8 @@
 				09E15A03160F57E2003025B4 /* OHAttributedLabel.m */,
 				0926A80E1698ADDD00573783 /* OHParagraphStyle.h */,
 				0926A80F1698ADDD00573783 /* OHParagraphStyle.m */,
+				C99D190017044B6200050CDC /* OHTouchesGestureRecognizer.h */,
+				C99D190117044B6200050CDC /* OHTouchesGestureRecognizer.m */,
 				09E15A00160F57E2003025B4 /* NSAttributedString+Attributes.h */,
 				09E15A01160F57E2003025B4 /* NSAttributedString+Attributes.m */,
 				09E15A27160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.h */,
@@ -224,6 +229,7 @@
 				0979355D1613A5AE006DB5D5 /* OHASBasicHTMLParser.m in Sources */,
 				097935611613B276006DB5D5 /* OHASBasicMarkupParser.m in Sources */,
 				0926A8111698ADDD00573783 /* OHParagraphStyle.m in Sources */,
+				C99D190217044B6300050CDC /* OHTouchesGestureRecognizer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OHAttributedLabel/Source/OHTouchesGestureRecognizer.h
+++ b/OHAttributedLabel/Source/OHTouchesGestureRecognizer.h
@@ -1,0 +1,32 @@
+/***********************************************************************************
+ * This software is under the MIT License quoted below:
+ ***********************************************************************************
+ *
+ * Copyright (c) 2013 Matt Galloway
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ ***********************************************************************************/
+
+
+#import <UIKit/UIKit.h>
+
+@interface OHTouchesGestureRecognizer : UIGestureRecognizer
+
+@end

--- a/OHAttributedLabel/Source/OHTouchesGestureRecognizer.m
+++ b/OHAttributedLabel/Source/OHTouchesGestureRecognizer.m
@@ -1,0 +1,72 @@
+/***********************************************************************************
+ * This software is under the MIT License quoted below:
+ ***********************************************************************************
+ *
+ * Copyright (c) 2013 Matt Galloway
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ ***********************************************************************************/
+
+
+#import "OHTouchesGestureRecognizer.h"
+
+#import <UIKit/UIGestureRecognizerSubclass.h>
+
+@interface OHTouchesGestureRecognizer ()
+
+@property (nonatomic, assign) CGPoint startPoint;
+
+@end
+
+@implementation OHTouchesGestureRecognizer
+
+@synthesize startPoint = _startPoint;
+
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+    self.startPoint = [(UITouch *)[touches anyObject] locationInView:self.view];
+    self.state = UIGestureRecognizerStateBegan;
+}
+
+- (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
+    UITouch *touch = (UITouch *)[touches anyObject];
+    CGPoint currentPoint = [touch locationInView:self.view];
+    CGFloat distanceX = (currentPoint.x - _startPoint.x);
+    CGFloat distanceY = (currentPoint.y - _startPoint.y);
+    CGFloat distance = sqrtf(distanceX * distanceX + distanceY * distanceY);
+    if (distance > 10.0f) {
+        self.state = UIGestureRecognizerStateCancelled;
+    } else {
+        self.state = UIGestureRecognizerStateChanged;
+    }
+}
+
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
+    self.state = UIGestureRecognizerStateEnded;
+}
+
+- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
+    self.state = UIGestureRecognizerStateCancelled;
+}
+
+- (void)reset {
+    self.state = UIGestureRecognizerStatePossible;
+}
+
+@end


### PR DESCRIPTION
Touch handling via touches(Began|Ended|Cancelled) is pretty old school. It also means that if you put an OHAttributedLabel inside a view that has a touch gesture recogniser on it then it won't fire on links being tapped as gesture recognisers use an inverted responder chain. These commits fix all that by converting OHAttributedLabel to use a gesture recogniser.
