### PR TITLE
Links don't highlight if no data detectors are set

### DIFF
--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -226,7 +226,17 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
     
     _needsRecomputeLinksInText = NO;
     
-    if (!_attributedText || (self.automaticallyAddLinksForType == 0 && _customLinks.count == 0))
+    __block NSUInteger OHLinkCount = 0;
+    [_attributedText enumerateAttribute:kOHLinkAttributeName inRange:NSMakeRange(0, [_attributedText length])
+                                options:0 usingBlock:^(id value, NSRange range, BOOL *stop)
+     {
+         if (value)
+         {
+             OHLinkCount++;
+         }
+     }];
+    
+    if (!_attributedText || (self.automaticallyAddLinksForType == 0 && _customLinks.count == 0 && OHLinkCount == 0))
     {
         MRC_RELEASE(_attributedTextWithLinks);
         _attributedTextWithLinks = MRC_RETAIN(_attributedText);


### PR DESCRIPTION
If there's no data detectors set, then recomputeLinksInTextIfNeeded returns early even if the links do need to be processed. This commit fixes that.
