### PR TITLE
Sometimes a run contains only some of a link

### DIFF
--- a/OHAttributedLabel/PrivateUtils/CoreTextUtils.h
+++ b/OHAttributedLabel/PrivateUtils/CoreTextUtils.h
@@ -55,5 +55,6 @@ NSRange NSRangeFromCFRange(CFRange range);
 
 CGRect CTLineGetTypographicBoundsAsRect(CTLineRef line, CGPoint lineOrigin);
 CGRect CTRunGetTypographicBoundsAsRect(CTRunRef run, CTLineRef line, CGPoint lineOrigin);
+CGRect CTRunGetTypographicBoundsForRangeAsRect(CTRunRef run, CTLineRef line, CGPoint lineOrigin, CFRange range, CGContextRef ctx);
 BOOL CTLineContainsCharactersFromStringRange(CTLineRef line, NSRange range);
 BOOL CTRunContainsCharactersFromStringRange(CTRunRef run, NSRange range);

--- a/OHAttributedLabel/PrivateUtils/CoreTextUtils.m
+++ b/OHAttributedLabel/PrivateUtils/CoreTextUtils.m
@@ -139,6 +139,16 @@ CGRect CTRunGetTypographicBoundsAsRect(CTRunRef run, CTLineRef line, CGPoint lin
 					  height);
 }
 
+CGRect CTRunGetTypographicBoundsForRangeAsRect(CTRunRef run, CTLineRef line, CGPoint lineOrigin, CFRange range, CGContextRef ctx)
+{
+    CGRect boundsOfRun = CTRunGetTypographicBoundsAsRect(run, line, lineOrigin);
+    CGRect boundsOfImageForRun = CTRunGetImageBounds(run, ctx, range);
+    return CGRectMake(boundsOfRun.origin.x + boundsOfImageForRun.origin.x,
+                      boundsOfRun.origin.y,
+                      boundsOfImageForRun.size.width,
+                      boundsOfRun.size.height);
+}
+
 BOOL CTLineContainsCharactersFromStringRange(CTLineRef line, NSRange range)
 {
 	NSRange lineRange = NSRangeFromCFRange(CTLineGetStringRange(line));

--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -635,7 +635,17 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
 				continue; // with next run
 			}
 			
-			CGRect linkRunRect = CTRunGetTypographicBoundsAsRect(run, line, lineOrigins[lineIndex]);
+            CFRange fullRunRange = CTRunGetStringRange(run);
+            
+            CFRange inRunRange;
+            inRunRange.location = (CFIndex)activeLinkRange.location - (CFIndex)fullRunRange.location;
+            inRunRange.length = (CFIndex)activeLinkRange.length;
+            if (inRunRange.location < 0) {
+                inRunRange.length += inRunRange.location;
+                inRunRange.location = 0;
+            }
+            
+            CGRect linkRunRect = CTRunGetTypographicBoundsForRangeAsRect(run, line, lineOrigins[lineIndex], inRunRange, ctx);
 			linkRunRect = CGRectIntegral(linkRunRect);		// putting the rect on pixel edges
 			linkRunRect = CGRectInset(linkRunRect, -1, -1);	// increase the rect a little
 			if (CGRectIsEmpty(unionRect))


### PR DESCRIPTION
Sometimes a CTRun contains only a few characters of a link. I found this often happens when the text is centered. These commits fix that problem.
