### PR TITLE
only setting OHATTRIBUTEDLABEL_WARN_ABOUT_KNOWN_ISSUES and OHATTRIBUTEDL...

### DIFF
--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -28,8 +28,12 @@
 #import "OHAttributedLabel.h"
 #import "CoreTextUtils.h"
 
+#ifndef OHATTRIBUTEDLABEL_WARN_ABOUT_KNOWN_ISSUES
 #define OHATTRIBUTEDLABEL_WARN_ABOUT_KNOWN_ISSUES 1
+#endif
+#ifndef OHATTRIBUTEDLABEL_WARN_ABOUT_OLD_API
 #define OHATTRIBUTEDLABEL_WARN_ABOUT_OLD_API 1
+#endif
 
 #ifndef OHATTRIBUTEDLABEL_DEDICATED_PROJECT
 // Copying files in your project and thus compiling OHAttributedLabel under different build settings


### PR DESCRIPTION
...ABEL_WARN_ABOUT_OLD_API if they where not defined otherwise before.

Hi!

I wanted to disable some warnings while using your OHAttributedLabels as an untouched cocoapod.
