### PR TITLE
Fix deprecation warnings for iOS 6.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@
 *.perspectivev3
 !default.perspectivev3
 xcuserdata
+xcshareddata
 profile
+Build
 *.moved-aside
 
 

--- a/OHAttributedLabel/OHAttributedLabel.xcodeproj/project.pbxproj
+++ b/OHAttributedLabel/OHAttributedLabel.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		09E15A26160F63DE003025B4 /* CoreTextUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E15A24160F63DE003025B4 /* CoreTextUtils.m */; };
 		09E15A2A160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E15A28160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.m */; };
 		09E15A2C160F64EB003025B4 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09E15A2B160F64EB003025B4 /* UIKit.framework */; };
+		C99D190217044B6300050CDC /* OHTouchesGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = C99D190117044B6200050CDC /* OHTouchesGestureRecognizer.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -70,6 +71,8 @@
 		09E15A27160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSTextCheckingResult+ExtendedURL.h"; sourceTree = "<group>"; };
 		09E15A28160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSTextCheckingResult+ExtendedURL.m"; sourceTree = "<group>"; };
 		09E15A2B160F64EB003025B4 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		C99D190017044B6200050CDC /* OHTouchesGestureRecognizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OHTouchesGestureRecognizer.h; sourceTree = "<group>"; };
+		C99D190117044B6200050CDC /* OHTouchesGestureRecognizer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OHTouchesGestureRecognizer.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -156,6 +159,8 @@
 				09E15A03160F57E2003025B4 /* OHAttributedLabel.m */,
 				0926A80E1698ADDD00573783 /* OHParagraphStyle.h */,
 				0926A80F1698ADDD00573783 /* OHParagraphStyle.m */,
+				C99D190017044B6200050CDC /* OHTouchesGestureRecognizer.h */,
+				C99D190117044B6200050CDC /* OHTouchesGestureRecognizer.m */,
 				09E15A00160F57E2003025B4 /* NSAttributedString+Attributes.h */,
 				09E15A01160F57E2003025B4 /* NSAttributedString+Attributes.m */,
 				09E15A27160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.h */,
@@ -224,6 +229,7 @@
 				0979355D1613A5AE006DB5D5 /* OHASBasicHTMLParser.m in Sources */,
 				097935611613B276006DB5D5 /* OHASBasicMarkupParser.m in Sources */,
 				0926A8111698ADDD00573783 /* OHParagraphStyle.m in Sources */,
+				C99D190217044B6300050CDC /* OHTouchesGestureRecognizer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OHAttributedLabel/OHAttributedLabel.xcodeproj/project.pbxproj
+++ b/OHAttributedLabel/OHAttributedLabel.xcodeproj/project.pbxproj
@@ -196,7 +196,7 @@
 		09E159DF160F573A003025B4 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0450;
+				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = AliSoftware;
 			};
 			buildConfigurationList = 09E159E2160F573A003025B4 /* Build configuration list for PBXProject "OHAttributedLabel" */;
@@ -260,7 +260,8 @@
 				GCC_WARN_SHADOW = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -282,7 +283,7 @@
 				GCC_WARN_SHADOW = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/OHAttributedLabel/PrivateUtils/CoreTextUtils.h
+++ b/OHAttributedLabel/PrivateUtils/CoreTextUtils.h
@@ -33,8 +33,13 @@
 #pragma mark - Text Alignment Convertion
 /////////////////////////////////////////////////////////////////////////////////////
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_6_0
 CTTextAlignment CTTextAlignmentFromUITextAlignment(UITextAlignment alignment);
 CTLineBreakMode CTLineBreakModeFromUILineBreakMode(UILineBreakMode lineBreakMode);
+#else
+CTTextAlignment CTTextAlignmentFromUITextAlignment(NSTextAlignment alignment);
+CTLineBreakMode CTLineBreakModeFromUILineBreakMode(NSLineBreakMode lineBreakMode);
+#endif
 
 /////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Flipping Coordinates

--- a/OHAttributedLabel/PrivateUtils/CoreTextUtils.h
+++ b/OHAttributedLabel/PrivateUtils/CoreTextUtils.h
@@ -55,5 +55,6 @@ NSRange NSRangeFromCFRange(CFRange range);
 
 CGRect CTLineGetTypographicBoundsAsRect(CTLineRef line, CGPoint lineOrigin);
 CGRect CTRunGetTypographicBoundsAsRect(CTRunRef run, CTLineRef line, CGPoint lineOrigin);
+CGRect CTRunGetTypographicBoundsForRangeAsRect(CTRunRef run, CTLineRef line, CGPoint lineOrigin, CFRange range, CGContextRef ctx);
 BOOL CTLineContainsCharactersFromStringRange(CTLineRef line, NSRange range);
 BOOL CTRunContainsCharactersFromStringRange(CTRunRef run, NSRange range);

--- a/OHAttributedLabel/PrivateUtils/CoreTextUtils.m
+++ b/OHAttributedLabel/PrivateUtils/CoreTextUtils.m
@@ -31,17 +31,22 @@
 #pragma mark - Text Alignment Convertion
 /////////////////////////////////////////////////////////////////////////////////////
 
-
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_6_0
 CTTextAlignment CTTextAlignmentFromUITextAlignment(UITextAlignment alignment)
 {
     if (alignment == (UITextAlignment)kCTJustifiedTextAlignment)
+#else
+CTTextAlignment CTTextAlignmentFromUITextAlignment(NSTextAlignment alignment)
+{
+    if (alignment == (NSTextAlignment)kCTJustifiedTextAlignment)
+#endif
     {
         /* special OOB value, so test it outside of the switch to avoid warning */
         return kCTJustifiedTextAlignment;
     }
 	switch (alignment)
     {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 60000
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_6_0
 		case UITextAlignmentLeft: return kCTLeftTextAlignment;
 		case UITextAlignmentCenter: return kCTCenterTextAlignment;
 		case UITextAlignmentRight: return kCTRightTextAlignment;
@@ -54,11 +59,15 @@ CTTextAlignment CTTextAlignmentFromUITextAlignment(UITextAlignment alignment)
 	}
 }
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_6_0
 CTLineBreakMode CTLineBreakModeFromUILineBreakMode(UILineBreakMode lineBreakMode)
+#else
+CTLineBreakMode CTLineBreakModeFromUILineBreakMode(NSLineBreakMode lineBreakMode)
+#endif
 {
 	switch (lineBreakMode)
     {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 60000
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_6_0
 		case UILineBreakModeWordWrap: return kCTLineBreakByWordWrapping;
 		case UILineBreakModeCharacterWrap: return kCTLineBreakByCharWrapping;
 		case UILineBreakModeClip: return kCTLineBreakByClipping;

--- a/OHAttributedLabel/PrivateUtils/CoreTextUtils.m
+++ b/OHAttributedLabel/PrivateUtils/CoreTextUtils.m
@@ -139,6 +139,16 @@ CGRect CTRunGetTypographicBoundsAsRect(CTRunRef run, CTLineRef line, CGPoint lin
 					  height);
 }
 
+CGRect CTRunGetTypographicBoundsForRangeAsRect(CTRunRef run, CTLineRef line, CGPoint lineOrigin, CFRange range, CGContextRef ctx)
+{
+    CGRect boundsOfRun = CTRunGetTypographicBoundsAsRect(run, line, lineOrigin);
+    CGRect boundsOfImageForRun = CTRunGetImageBounds(run, ctx, range);
+    return CGRectMake(boundsOfRun.origin.x + boundsOfImageForRun.origin.x,
+                      boundsOfRun.origin.y,
+                      boundsOfImageForRun.size.width,
+                      boundsOfRun.size.height);
+}
+
 BOOL CTLineContainsCharactersFromStringRange(CTLineRef line, NSRange range)
 {
 	NSRange lineRange = NSRangeFromCFRange(CTLineGetStringRange(line));

--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -731,6 +731,7 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
     {
         [mutAttrStr setTextColor:self.textColor];
     }
+    
 	CTTextAlignment coreTextAlign = CTTextAlignmentFromUITextAlignment(self.textAlignment);
 	CTLineBreakMode coreTextLBMode = CTLineBreakModeFromUILineBreakMode(self.lineBreakMode);
 	[mutAttrStr setTextAlignment:coreTextAlign lineBreakMode:coreTextLBMode];
@@ -794,7 +795,11 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
 	[super setTextColor:color]; // will call setNeedsDisplay too
 }
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_6_0
 -(void)setTextAlignment:(UITextAlignment)alignment
+#else
+-(void)setTextAlignment:(NSTextAlignment)alignment
+#endif
 {
     if (_attributedText)
     {
@@ -808,7 +813,11 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
 	[super setTextAlignment:alignment]; // will call setNeedsDisplay too
 }
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_6_0
 -(void)setLineBreakMode:(UILineBreakMode)lineBreakMode
+#else
+-(void)setLineBreakMode:(NSLineBreakMode)lineBreakMode
+#endif
 {
     if (_attributedText)
     {

--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -642,7 +642,17 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
 				continue; // with next run
 			}
 			
-			CGRect linkRunRect = CTRunGetTypographicBoundsAsRect(run, line, lineOrigins[lineIndex]);
+            CFRange fullRunRange = CTRunGetStringRange(run);
+            
+            CFRange inRunRange;
+            inRunRange.location = (CFIndex)activeLinkRange.location - (CFIndex)fullRunRange.location;
+            inRunRange.length = (CFIndex)activeLinkRange.length;
+            if (inRunRange.location < 0) {
+                inRunRange.length += inRunRange.location;
+                inRunRange.location = 0;
+            }
+            
+            CGRect linkRunRect = CTRunGetTypographicBoundsForRangeAsRect(run, line, lineOrigins[lineIndex], inRunRange, ctx);
 			linkRunRect = CGRectIntegral(linkRunRect);		// putting the rect on pixel edges
 			linkRunRect = CGRectInset(linkRunRect, -1, -1);	// increase the rect a little
 			if (CGRectIsEmpty(unionRect))

--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -232,7 +232,17 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
     
     _needsRecomputeLinksInText = NO;
     
-    if (!_attributedText || (self.automaticallyAddLinksForType == 0 && _customLinks.count == 0))
+    __block NSUInteger OHLinkCount = 0;
+    [_attributedText enumerateAttribute:kOHLinkAttributeName inRange:NSMakeRange(0, [_attributedText length])
+                                options:0 usingBlock:^(id value, NSRange range, BOOL *stop)
+     {
+         if (value)
+         {
+             OHLinkCount++;
+         }
+     }];
+    
+    if (!_attributedText || (self.automaticallyAddLinksForType == 0 && _customLinks.count == 0 && OHLinkCount == 0))
     {
         MRC_RELEASE(_attributedTextWithLinks);
         _attributedTextWithLinks = MRC_RETAIN(_attributedText);

--- a/OHAttributedLabel/Source/OHTouchesGestureRecognizer.h
+++ b/OHAttributedLabel/Source/OHTouchesGestureRecognizer.h
@@ -1,0 +1,32 @@
+/***********************************************************************************
+ * This software is under the MIT License quoted below:
+ ***********************************************************************************
+ *
+ * Copyright (c) 2013 Matt Galloway
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ ***********************************************************************************/
+
+
+#import <UIKit/UIKit.h>
+
+@interface OHTouchesGestureRecognizer : UIGestureRecognizer
+
+@end

--- a/OHAttributedLabel/Source/OHTouchesGestureRecognizer.m
+++ b/OHAttributedLabel/Source/OHTouchesGestureRecognizer.m
@@ -1,0 +1,72 @@
+/***********************************************************************************
+ * This software is under the MIT License quoted below:
+ ***********************************************************************************
+ *
+ * Copyright (c) 2013 Matt Galloway
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ ***********************************************************************************/
+
+
+#import "OHTouchesGestureRecognizer.h"
+
+#import <UIKit/UIGestureRecognizerSubclass.h>
+
+@interface OHTouchesGestureRecognizer ()
+
+@property (nonatomic, assign) CGPoint startPoint;
+
+@end
+
+@implementation OHTouchesGestureRecognizer
+
+@synthesize startPoint = _startPoint;
+
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+    self.startPoint = [(UITouch *)[touches anyObject] locationInView:self.view];
+    self.state = UIGestureRecognizerStateBegan;
+}
+
+- (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
+    UITouch *touch = (UITouch *)[touches anyObject];
+    CGPoint currentPoint = [touch locationInView:self.view];
+    CGFloat distanceX = (currentPoint.x - _startPoint.x);
+    CGFloat distanceY = (currentPoint.y - _startPoint.y);
+    CGFloat distance = sqrtf(distanceX * distanceX + distanceY * distanceY);
+    if (distance > 10.0f) {
+        self.state = UIGestureRecognizerStateCancelled;
+    } else {
+        self.state = UIGestureRecognizerStateChanged;
+    }
+}
+
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
+    self.state = UIGestureRecognizerStateEnded;
+}
+
+- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
+    self.state = UIGestureRecognizerStateCancelled;
+}
+
+- (void)reset {
+    self.state = UIGestureRecognizerStatePossible;
+}
+
+@end


### PR DESCRIPTION
Used iOS version preprocessor macros to remove deprecations when building for iOS 6.0+.
