### PR TITLE
Fixed iOS5 crash

### DIFF
--- a/OHAttributedLabel.podspec
+++ b/OHAttributedLabel.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name     = 'OHAttributedLabel'
+  s.version  = '3.4.2'
+  s.license  = {:type => 'MIT', :file => 'OHAttributedLabel/LICENSE'}
+  s.summary  = 'UILabel that supports NSAttributedString.'
+  s.homepage = 'https://github.com/AliSoftware/OHAttributedLabel'
+  s.author   = { 'AliSoftware' => 'olivier.halligon+ae@gmail.com' }
+  s.source   = { :git => 'https://github.com/AliSoftware/OHAttributedLabel.git', :tag => s.version.to_s }
+  s.description = 'This class allows you to use a `UILabel` with `NSAttributedStrings`, in order to display styled text with mixed style (mixed fonts, color, size, ...) in a unique label.
+  It also provides a `NSAttributedString` category with a lot of commodity methods to change its various style & fonts, and some easy to use parsers to build your complex `NSAttributedStrings` (containing various/mixed styles) very easily.'
+  s.platform = :ios
+  s.source_files = 'OHAttributedLabel/**/*.{h,m}'
+  s.framework = 'CoreText'
+end

--- a/OHAttributedLabel/PrivateUtils/CoreTextUtils.m
+++ b/OHAttributedLabel/PrivateUtils/CoreTextUtils.m
@@ -33,7 +33,7 @@
 
 CTTextAlignment CTTextAlignmentFromUITextAlignment(NSUITextAlignment alignment)
 {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 60000
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0
     if (alignment == (NSUITextAlignment)kCTJustifiedTextAlignment)
     {
         /* special OOB value, so test it outside of the switch to avoid warning */


### PR DESCRIPTION
When using an app with OHAttributedLabel on iOS 5 it will crash with:

```
dyld: lazy symbol binding failed: Symbol not found: _NSTextAlignmentToCTTextAlignment
  Referenced from: /Users/cristi/Library/Application Support/iPhone Simulator/5.0/Applications/78925988-57FD-49D3-B088-0C9D80F462E1/OHAttributedLabelIOS5Bug.app/OHAttributedLabelIOS5Bug
  Expected in: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator5.0.sdk/System/Library/Frameworks/UIKit.framework/UIKit

dyld: Symbol not found: _NSTextAlignmentToCTTextAlignment
  Referenced from: /Users/cristi/Library/Application Support/iPhone Simulator/5.0/Applications/78925988-57FD-49D3-B088-0C9D80F462E1/OHAttributedLabelIOS5Bug.app/OHAttributedLabelIOS5Bug
  Expected in: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator5.0.sdk/System/Library/Frameworks/UIKit.framework/UIKit
```

That's because when using iOS6+ symbols you're checking for the base SDK 

```
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 60000
```

and not for the deployment target

```
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0
```

Here's an example: https://github.com/cristianbica/OHAttributedLabelIOS5Bug
To reproduce:
- run pod install
- run the app from XCode
- it will crash
- modify the Podfile to use my fork
- it won't crash

notes:
1. I've added a podspec so the example project will work
2. I've modified just in OHAttributedLabel/PrivateUtils/CoreTextUtils.m as this is where it crashed but probably we need to change this in the whole project
