### PR TITLE
Adds Copy Header task to the Build Phase to fix the need to create a configuration for OHAttributedLabel when using configurations other than Debug and Release

### DIFF
--- a/OHAttributedLabel/OHAttributedLabel.xcodeproj/project.pbxproj
+++ b/OHAttributedLabel/OHAttributedLabel.xcodeproj/project.pbxproj
@@ -11,13 +11,13 @@
 		09793559161393F2006DB5D5 /* OHASMarkupParserBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 09793557161393F2006DB5D5 /* OHASMarkupParserBase.m */; };
 		0979355D1613A5AE006DB5D5 /* OHASBasicHTMLParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 0979355B1613A5AE006DB5D5 /* OHASBasicHTMLParser.m */; };
 		097935611613B276006DB5D5 /* OHASBasicMarkupParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 0979355F1613B276006DB5D5 /* OHASBasicMarkupParser.m */; };
-		09804E0716A8CAA400ADC660 /* OHAttributedLabel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 09E15A02160F57E2003025B4 /* OHAttributedLabel.h */; };
-		09804E0816A8CAA400ADC660 /* OHParagraphStyle.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0926A80E1698ADDD00573783 /* OHParagraphStyle.h */; };
-		09804E0916A8CAA400ADC660 /* NSAttributedString+Attributes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 09E15A00160F57E2003025B4 /* NSAttributedString+Attributes.h */; };
-		09804E0A16A8CAA400ADC660 /* NSTextCheckingResult+ExtendedURL.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 09E15A27160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.h */; };
-		09804E0B16A8CAA400ADC660 /* OHASMarkupParserBase.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 09793556161393F2006DB5D5 /* OHASMarkupParserBase.h */; };
-		09804E0C16A8CAA400ADC660 /* OHASBasicHTMLParser.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0979355A1613A5AE006DB5D5 /* OHASBasicHTMLParser.h */; };
-		09804E0D16A8CAA400ADC660 /* OHASBasicMarkupParser.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0979355E1613B276006DB5D5 /* OHASBasicMarkupParser.h */; };
+		09804E0716A8CAA400ADC660 /* OHAttributedLabel.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 09E15A02160F57E2003025B4 /* OHAttributedLabel.h */; };
+		09804E0816A8CAA400ADC660 /* OHParagraphStyle.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 0926A80E1698ADDD00573783 /* OHParagraphStyle.h */; };
+		09804E0916A8CAA400ADC660 /* NSAttributedString+Attributes.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 09E15A00160F57E2003025B4 /* NSAttributedString+Attributes.h */; };
+		09804E0A16A8CAA400ADC660 /* NSTextCheckingResult+ExtendedURL.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 09E15A27160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.h */; };
+		09804E0B16A8CAA400ADC660 /* OHASMarkupParserBase.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 09793556161393F2006DB5D5 /* OHASMarkupParserBase.h */; };
+		09804E0C16A8CAA400ADC660 /* OHASBasicHTMLParser.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 0979355A1613A5AE006DB5D5 /* OHASBasicHTMLParser.h */; };
+		09804E0D16A8CAA400ADC660 /* OHASBasicMarkupParser.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 0979355E1613B276006DB5D5 /* OHASBasicMarkupParser.h */; };
 		09E159EC160F573A003025B4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09E159EB160F573A003025B4 /* Foundation.framework */; };
 		09E159FE160F57AB003025B4 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09E159FD160F57AB003025B4 /* CoreText.framework */; };
 		09E15A04160F57E2003025B4 /* NSAttributedString+Attributes.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E15A01160F57E2003025B4 /* NSAttributedString+Attributes.m */; };
@@ -25,23 +25,32 @@
 		09E15A26160F63DE003025B4 /* CoreTextUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E15A24160F63DE003025B4 /* CoreTextUtils.m */; };
 		09E15A2A160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E15A28160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.m */; };
 		09E15A2C160F64EB003025B4 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09E15A2B160F64EB003025B4 /* UIKit.framework */; };
+		7739076117EFD5FB00FC9DB5 /* OHAttributedLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E15A02160F57E2003025B4 /* OHAttributedLabel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7739076217EFD5FC00FC9DB5 /* OHParagraphStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 0926A80E1698ADDD00573783 /* OHParagraphStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7739076317EFD5FE00FC9DB5 /* NSAttributedString+Attributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E15A00160F57E2003025B4 /* NSAttributedString+Attributes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7739076417EFD60200FC9DB5 /* NSTextCheckingResult+ExtendedURL.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E15A27160F640D003025B4 /* NSTextCheckingResult+ExtendedURL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7739076517EFD60800FC9DB5 /* CoreTextUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E15A23160F63DE003025B4 /* CoreTextUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7739076617EFD68F00FC9DB5 /* OHASMarkupParserBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 09793556161393F2006DB5D5 /* OHASMarkupParserBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7739076717EFD69200FC9DB5 /* OHASBasicHTMLParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 0979355A1613A5AE006DB5D5 /* OHASBasicHTMLParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7739076817EFD69400FC9DB5 /* OHASBasicMarkupParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 0979355E1613B276006DB5D5 /* OHASBasicMarkupParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		09804E0516A8CA8800ADC660 /* CopyFiles */ = {
+		09804E0516A8CA8800ADC660 /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
-				09804E0716A8CAA400ADC660 /* OHAttributedLabel.h in CopyFiles */,
-				09804E0816A8CAA400ADC660 /* OHParagraphStyle.h in CopyFiles */,
-				09804E0916A8CAA400ADC660 /* NSAttributedString+Attributes.h in CopyFiles */,
-				09804E0A16A8CAA400ADC660 /* NSTextCheckingResult+ExtendedURL.h in CopyFiles */,
-				09804E0B16A8CAA400ADC660 /* OHASMarkupParserBase.h in CopyFiles */,
-				09804E0C16A8CAA400ADC660 /* OHASBasicHTMLParser.h in CopyFiles */,
-				09804E0D16A8CAA400ADC660 /* OHASBasicMarkupParser.h in CopyFiles */,
+				09804E0716A8CAA400ADC660 /* OHAttributedLabel.h in Copy Files */,
+				09804E0816A8CAA400ADC660 /* OHParagraphStyle.h in Copy Files */,
+				09804E0916A8CAA400ADC660 /* NSAttributedString+Attributes.h in Copy Files */,
+				09804E0A16A8CAA400ADC660 /* NSTextCheckingResult+ExtendedURL.h in Copy Files */,
+				09804E0B16A8CAA400ADC660 /* OHASMarkupParserBase.h in Copy Files */,
+				09804E0C16A8CAA400ADC660 /* OHASBasicHTMLParser.h in Copy Files */,
+				09804E0D16A8CAA400ADC660 /* OHASBasicMarkupParser.h in Copy Files */,
 			);
+			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -167,6 +176,24 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		7739076017EFD5F200FC9DB5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7739076117EFD5FB00FC9DB5 /* OHAttributedLabel.h in Headers */,
+				7739076217EFD5FC00FC9DB5 /* OHParagraphStyle.h in Headers */,
+				7739076317EFD5FE00FC9DB5 /* NSAttributedString+Attributes.h in Headers */,
+				7739076417EFD60200FC9DB5 /* NSTextCheckingResult+ExtendedURL.h in Headers */,
+				7739076517EFD60800FC9DB5 /* CoreTextUtils.h in Headers */,
+				7739076617EFD68F00FC9DB5 /* OHASMarkupParserBase.h in Headers */,
+				7739076717EFD69200FC9DB5 /* OHASBasicHTMLParser.h in Headers */,
+				7739076817EFD69400FC9DB5 /* OHASBasicMarkupParser.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
 		09E159E7160F573A003025B4 /* OHAttributedLabel */ = {
 			isa = PBXNativeTarget;
@@ -174,7 +201,8 @@
 			buildPhases = (
 				09E159E4160F573A003025B4 /* Sources */,
 				09E159E5160F573A003025B4 /* Frameworks */,
-				09804E0516A8CA8800ADC660 /* CopyFiles */,
+				7739076017EFD5F200FC9DB5 /* Headers */,
+				09804E0516A8CA8800ADC660 /* Copy Files */,
 			);
 			buildRules = (
 			);
@@ -256,6 +284,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				ONLY_ACTIVE_ARCH = YES;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -278,6 +307,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -299,6 +329,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "../../Headers/$(PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -319,6 +350,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "../../Headers/$(PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 			};
 			name = Release;


### PR DESCRIPTION
Instead of having to change the project settings whenever you are archiving or building using a configuration that is not the default Debug or Release, this pull request makes it so you can always archive and build no matter the configuration. The project using OHAttributed label needs to specify: "$(BUILT_PRODUCTS_DIR)/../../Headers" as a User Header Search path (including quotes) and $(OBJROOT)/UninstalledProducts as a Library Search Path
