### PR TITLE
Optimize call to canOpenURL: to improve performance

### DIFF
--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -136,7 +136,13 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
 	_linkUnderlineStyle = kCTUnderlineStyleSingle | kCTUnderlinePatternSolid;
     
 	NSTextCheckingTypes linksType = (NSTextCheckingTypes)(NSTextCheckingTypeLink);
-	if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"tel:0"]])
+	
+	static dispatch_once_t onceToken;
+	static BOOL canOpenURL;
+	dispatch_once(&onceToken, ^{
+		canOpenURL = [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"tel:0"]];
+	});
+	if (canOpenURL)
     {
 		linksType |= NSTextCheckingTypePhoneNumber;
 	}
@@ -196,6 +202,11 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
 /////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Links Managment
 /////////////////////////////////////////////////////////////////////////////////////
+
+-(void)setDetectsPhoneNumbers:(BOOL)detectsPhoneNumbers
+{
+	
+}
 
 -(void)addCustomLink:(NSURL*)linkUrl inRange:(NSRange)range
 {


### PR DESCRIPTION
I'm using OHAtributedLabel a lot in the tableviewcells, so recently I've encountered this performance issue during `commonInit`:
![123](https://f.cloud.github.com/assets/829783/1244788/870b17b8-2a8e-11e3-8a4e-bff68c98d850.png)

I've fixed it by asking the app if it can handle numbers only once.
