### PR TITLE
Fix where the highlight is made if it spans multiple lines

### DIFF
--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -664,16 +664,15 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
 				continue; // with next run
 			}
             
-            // Fix for issue #136
             CFRange fullRunRange = CTRunGetStringRange(run);
+
+            CFIndex startActiveLinkInRun = (CFIndex)activeLinkRange.location - fullRunRange.location;
+            CFIndex endActiveLinkInRun = startActiveLinkInRun + (CFIndex)activeLinkRange.length;
+            
             CFRange inRunRange;
-            inRunRange.location = (CFIndex)activeLinkRange.location - (CFIndex)fullRunRange.location;
-            inRunRange.length = (CFIndex)activeLinkRange.length;
-            if (inRunRange.location < 0) {
-                inRunRange.length += inRunRange.location;
-                inRunRange.location = 0;
-            }
-            // End Fix #136
+            inRunRange.location = MAX(startActiveLinkInRun, 0);
+            inRunRange.length = MIN(endActiveLinkInRun, fullRunRange.length);
+            
             CGRect linkRunRect = CTRunGetTypographicBoundsForRangeAsRect(run, line, lineOrigins[lineIndex], inRunRange, ctx);
             
 			linkRunRect = CGRectIntegral(linkRunRect);		// putting the rect on pixel edges


### PR DESCRIPTION
This fixes highlights that span multiple lines because the highlight range was not being calculated correctly for subsequent lines.

[Apologies, my original PR (#136) introduced this bug]
