### PR TITLE
Add requires ARC - it's best to use ARC, so let's make it use it

### DIFF
--- a/OHAttributedLabel.podspec
+++ b/OHAttributedLabel.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |s|
   s.platform = :ios
   s.source_files = 'OHAttributedLabel/**/*.{h,m}'
   s.framework = 'CoreText'
+  s.requires_arc = true
 end


### PR DESCRIPTION
As title. Probably best to make OHAttributedLabel use ARC by default in CocoaPods, because, well, ARC is best :-).
