### PR TITLE
OHAttributedLabel doesn't work with autolayout

### DIFF
--- a/OHAttributedLabel/Source/NSAttributedString+Attributes.m
+++ b/OHAttributedLabel/Source/NSAttributedString+Attributes.m
@@ -26,6 +26,7 @@
 
 
 #import "NSAttributedString+Attributes.h"
+#import "tgmath.h"
 
 #if ! defined(COCOAPODS) && ! defined(OHATTRIBUTEDLABEL_DEDICATED_PROJECT)
 // Copying files in your project and thus compiling OHAttributedLabel under different build settings
@@ -71,7 +72,7 @@ NSString* kOHLinkAttributeName = @"NSLinkAttributeName"; // Use the same value a
     {
         CFRange fitCFRange = CFRangeMake(0,0);
         sz = CTFramesetterSuggestFrameSizeWithConstraints(framesetter,CFRangeMake(0,0),NULL,maxSize,&fitCFRange);
-        sz = CGSizeMake( floorf(sz.width+1) , floorf(sz.height+1) ); // take 1pt of margin for security
+        sz = CGSizeMake( floor(sz.width+1) , floor(sz.height+1) ); // take 1pt of margin for security
         CFRelease(framesetter);
 
         if (fitRange)
@@ -348,7 +349,7 @@ static NSString* const kHelveticaNeueUI_Bold_Italic = @".HelveticaNeueUI-BoldIta
 }
 -(void)setCharacterSpacing:(CGFloat)chracterSpacing range:(NSRange)range
 {
-    [self addAttribute:(NSString *)kCTKernAttributeName value:[NSNumber numberWithFloat:chracterSpacing] range:range];
+    [self addAttribute:(NSString *)kCTKernAttributeName value:[NSNumber numberWithDouble:chracterSpacing] range:range];
 }
 
 -(void)modifyParagraphStylesWithBlock:(void(^)(OHParagraphStyle* paragraphStyle))block

--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -737,6 +737,7 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
 	[self removeAllCustomLinks];
 #pragma clang diagnostic pop
     [self setNeedsRecomputeLinksInText];
+    [super setAttributedText:newText];
 }
 
 

--- a/OHAttributedLabel/Source/OHAttributedLabel.m
+++ b/OHAttributedLabel/Source/OHAttributedLabel.m
@@ -28,6 +28,7 @@
 #import "OHAttributedLabel.h"
 #import "CoreTextUtils.h"
 #import "OHTouchesGestureRecognizer.h"
+#import "tgmath.h"
 
 #ifndef OHATTRIBUTEDLABEL_WARN_ABOUT_KNOWN_ISSUES
 #define OHATTRIBUTEDLABEL_WARN_ABOUT_KNOWN_ISSUES 1
@@ -556,7 +557,7 @@ NSDataDetector* sharedReusableDataDetector(NSTextCheckingTypes types)
                     CGSize sz = CTFramesetterSuggestFrameSizeWithConstraints(framesetter,CFRangeMake(0,0),NULL,CGSizeMake(drawingRect.size.width,CGFLOAT_MAX),NULL);
                     if (self.extendBottomToFit)
                     {
-                        CGFloat delta = MAX(0.f , ceilf(sz.height - drawingRect.size.height)) + 10 /* Security margin */;
+                        CGFloat delta = MAX(0.f , ceil(sz.height - drawingRect.size.height)) + 10 /* Security margin */;
                         drawingRect.origin.y -= delta;
                         drawingRect.size.height += delta;
                     }

--- a/OHAttributedLabel/Source/OHTouchesGestureRecognizer.m
+++ b/OHAttributedLabel/Source/OHTouchesGestureRecognizer.m
@@ -26,6 +26,7 @@
 
 
 #import "OHTouchesGestureRecognizer.h"
+#import "tgmath.h"
 
 #import <UIKit/UIGestureRecognizerSubclass.h>
 
@@ -49,7 +50,7 @@
     CGPoint currentPoint = [touch locationInView:self.view];
     CGFloat distanceX = (currentPoint.x - _startPoint.x);
     CGFloat distanceY = (currentPoint.y - _startPoint.y);
-    CGFloat distance = sqrtf(distanceX * distanceX + distanceY * distanceY);
+    CGFloat distance = sqrt(distanceX * distanceX + distanceY * distanceY);
     if (distance > 10.0f) {
         self.state = UIGestureRecognizerStateCancelled;
     } else {


### PR DESCRIPTION
If you create an OHAttributedLabel without a frame and position it using autolayout, it has 0 height. This is because when intrinsicContentSize is invoked, attributedText is not set in the UILabel superclass, so the label appears to be empty. Setting the attributedText on the UILabel superclass allows it to calculate the intrinsicContentSize, without any apparent side effects.
